### PR TITLE
Atualização quanto alguns motores

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,18 +136,18 @@ This is released under a Creative Commons Attribution Share A like license, vers
 
 ## Game Engines
 
-- [Amazon Lumberyard](https://aws.amazon.com/pt/lumberyard/)
-- [Blender Game Engine](https://www.blender.org/)
+- [Open 3D Engine](https://www.o3de.org/)
+- [UPBGE](https://upbge.org/)
 - [Construct](https://www.construct.net/)
 - [CryEngine](https://www.cryengine.com/)
-- [GameMaker Studio](https://www.yoyogames.com/gamemaker)
+- [GameMaker](https://gamemaker.io/pt-BR)
 - [Godot](https://godotengine.org/)
-- [Irrlicht](http://irrlicht.sourceforge.net/)
+- [Irrlicht](https://irrlicht.sourceforge.io/)
 - [JNGL](https://github.com/jhasse/jngl)
-- [OGRE(Object-Oriented Graphics Rendering Engine)](https://www.ogre3d.org/)
-- [Unity3D](http://www.unity3d.com)
-- [Unreal Development Kit](http://www.unrealengine.com)
-- [Xenko](http://www.xenko.com)
+- [OGRE (Object-Oriented Graphics Rendering Engine)](https://www.ogre3d.org/)
+- [Unity](https://unity.com/pt/)
+- [Unreal Engine](https://www.unrealengine.com/pt-BR)
+- [Stride](https://www.stride3d.net/)
 
 ## Game Libs and Frameworks
 
@@ -163,9 +163,9 @@ This is released under a Creative Commons Attribution Share A like license, vers
 
 ### Graphics
 
-- [DirectX](https://blogs.msdn.microsoft.com/directx/)
+- [DirectX](https://devblogs.microsoft.com/directx/)
 - [OpenGL](https://www.opengl.org/)
-- [Vulkan](https://www.khronos.org/vulkan/)
+- [Vulkan](https://www.vulkan.org/)
 
 ## Portifolios Examples
 


### PR DESCRIPTION
* [Lumbeyard foi descontinuado em favor à Open 3D Engine](https://aws.amazon.com/pt/blogs/gametech/open-3d-engine/).
* [Xenko foi renomeado para Stride](https://www.stride3d.net/blog/xenko-has-been-renamed-to-stride/)
* [Blender Game Engine foi removida](https://www.blender.org/download/releases/2-80/#compatibility), [a comunidade adotou a bifurcação UPBGE como sucessora](https://en.wikipedia.org/wiki/Blender_Game_Engine#History)
* [Irrlicht teve URL atualizada para o domínio `io`](https://irrlicht.sourceforge.io/?p=1708)

Além de mudar certas páginas pro idioma `pt-BR` e outras URLs.